### PR TITLE
Update to_location.py

### DIFF
--- a/src/maidenhead/to_location.py
+++ b/src/maidenhead/to_location.py
@@ -25,7 +25,7 @@ def to_location(maiden: str, center: bool = False) -> tuple[float, float]:
     maiden = maiden.strip().upper()
 
     N = len(maiden)
-    if not 8 >= N >= 2 and N % 2 == 0:
+    if not((8 >= N >= 2) and (N % 2 == 0)):
         raise ValueError("Maidenhead locator requires 2-8 characters, even number of characters")
 
     Oa = ord("A")


### PR DESCRIPTION
Fixed a problem with unexpected behaviour if `to_location()` is called with an invalid maidenhead-strings containing an uneven number of characters such as 'JO40ik0', etc.

With the proposed changes a ValueError is raised in this case.