### PR TITLE
add precision up to 6 pairs in maidenhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Maidenhead provides 4 levels of increasing accuracy
   2     |  Regional
   3     |  Metropolis
   4     |  City
+  5     |  Street
+  6     |  1m precision
 
 ```sh
 pip install maidenhead
@@ -81,3 +83,5 @@ The `--center` option outputs lat lon of the center of provided maidenhead grid 
 
 Open Location Codes a.k.a Plus Codes are in
 [Python code by Google](https://github.com/google/open-location-code/tree/master/python).
+
+Web convertor [Earth Point - Tools for Google Earth](https://www.earthpoint.us/Convert.aspx).

--- a/src/maidenhead/__main__.py
+++ b/src/maidenhead/__main__.py
@@ -7,7 +7,7 @@ import maidenhead
 
 def main(
     loc: str | tuple[float, float],
-    precision: int = 3,
+    precision: int = 6,
     url: bool = False,
     center: bool = False,
 ) -> str | tuple[float, float]:
@@ -15,7 +15,7 @@ def main(
     if isinstance(loc, str):  # maidenhead
         maiden = copy(loc)
         loc = maidenhead.to_location(loc, center)
-        print(f"{loc[0]:.4f} {loc[1]:.4f}")
+        print(f"{loc[0]:.7f} {loc[1]:.7f}")
     elif len(loc) == 2:  # lat lon
         if isinstance(loc[0], str):
             loc = (float(loc[0]), float(loc[1]))

--- a/src/maidenhead/to_location.py
+++ b/src/maidenhead/to_location.py
@@ -9,7 +9,7 @@ def to_location(maiden: str, center: bool = False) -> tuple[float, float]:
     ----------
 
     maiden : str
-        Maidenhead grid locator of length 2 to 8
+        Maidenhead grid locator of length 2 to 12
 
     center : bool
         If true, return the center of provided maidenhead grid square, instead of default south-west corner
@@ -25,12 +25,15 @@ def to_location(maiden: str, center: bool = False) -> tuple[float, float]:
     maiden = maiden.strip().upper()
 
     N = len(maiden)
-    if not ((8 >= N >= 2) and (N % 2 == 0)):
-        raise ValueError("Maidenhead locator requires 2-8 characters, even number of characters")
+    if not ((12 >= N >= 2) and (N % 2 == 0)):
+        raise ValueError("Maidenhead locator requires 2-12 characters, even number of characters")
 
     Oa = ord("A")
     lon = -180.0
     lat = -90.0
+    # cf. https://en.wikipedia.org/wiki/Maidenhead_Locator_System
+    # cf. https://fastapi.metacpan.org/source/MEH/Ham-Locator-0.1000/lib/Ham/Locator.pm
+    # cf. https://www.earthpoint.us/Convert.aspx
     # %% first pair
     lon += (ord(maiden[0]) - Oa) * 20
     lat += (ord(maiden[1]) - Oa) * 10
@@ -40,13 +43,23 @@ def to_location(maiden: str, center: bool = False) -> tuple[float, float]:
         lat += int(maiden[3]) * 1
     # %%
     if N >= 6:
-        lon += (ord(maiden[4]) - Oa) * 5.0 / 60
-        lat += (ord(maiden[5]) - Oa) * 2.5 / 60
+        lon += (ord(maiden[4]) - Oa) * 0.0833333 # 5' in degrees
+        lat += (ord(maiden[5]) - Oa) * 0.0416667 # 2.5' in degrees
     # %%
     if N >= 8:
-        lon += int(maiden[6]) * 5.0 / 600
-        lat += int(maiden[7]) * 2.5 / 600
+        lon += int(maiden[6]) * 0.0083333 # 30" in degrees
+        lat += int(maiden[7]) * 0.0041667 # 15" in degrees
 
+    # %%
+    if N >= 10:
+        lon += (ord(maiden[8]) - Oa) * (0.0083333/24) # 30" / 24 in degrees
+        lat += (ord(maiden[9]) - Oa) * (0.0041667/24) # 15" / 24 in degrees
+
+    # %%
+    if N >= 12:
+        lon += int(maiden[10]) * (0.0083333/(24*10))
+        lat += int(maiden[11]) * (0.0041667/(24*10))
+        
     # %% move lat lon to the center (if requested)
     if center:
         if N == 2:
@@ -56,10 +69,16 @@ def to_location(maiden: str, center: bool = False) -> tuple[float, float]:
             lon += 2 / 2
             lat += 1.0 / 2
         elif N == 6:
-            lon += 5.0 / 60 / 2
-            lat += 2.5 / 60 / 2
-        elif N >= 8:
-            lon += 5.0 / 600 / 2
-            lat += 2.5 / 600 / 2
+            lon += 0.0833333 / 2
+            lat += 0.0416667 / 2
+        elif N == 8:
+            lon += 0.0083333 / 2
+            lat += 0.0041667 / 2
+        elif N == 10:
+            lon += (0.0083333/24) / 2
+            lat += (0.0041667/24) / 2
+        elif N == 12:
+            lon += (0.0083333/(24*10)) / 2
+            lat += (0.0041667/(24*10)) / 2
 
     return lat, lon


### PR DESCRIPTION
This modification aims to add more precision to maidenhead's code. Up to 6 pairs like JN19CF83FC56 is now possible!

References:

- [Wikipedia](https://en.wikipedia.org/wiki/Maidenhead_Locator_System)
- [Perl Ham Locator's code](https://fastapi.metacpan.org/source/MEH/Ham-Locator-0.1000/lib/Ham/Locator.pm)
- [Earth Point | Tools for Google Earth](https://www.earthpoint.us/Convert.aspx)