### PR TITLE
Changed the way conversions are performed. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Maidenhead provides 4 levels of increasing accuracy
   2     |  Regional
   3     |  Metropolis
   4     |  City
+  5     |  Street
+  6     |  1m precision
 
 ```sh
 pip install maidenhead
@@ -81,3 +83,5 @@ The `--center` option outputs lat lon of the center of provided maidenhead grid 
 
 Open Location Codes a.k.a Plus Codes are in
 [Python code by Google](https://github.com/google/open-location-code/tree/master/python).
+
+Web convertor [Earth Point - Tools for Google Earth](https://www.earthpoint.us/Convert.aspx).

--- a/src/maidenhead/__main__.py
+++ b/src/maidenhead/__main__.py
@@ -7,7 +7,7 @@ import maidenhead
 
 def main(
     loc: str | tuple[float, float],
-    precision: int = 3,
+    precision: int = 6,
     url: bool = False,
     center: bool = False,
 ) -> str | tuple[float, float]:
@@ -15,7 +15,7 @@ def main(
     if isinstance(loc, str):  # maidenhead
         maiden = copy(loc)
         loc = maidenhead.to_location(loc, center)
-        print(f"{loc[0]:.4f} {loc[1]:.4f}")
+        print(f"{loc[0]:.7f} {loc[1]:.7f}")
     elif len(loc) == 2:  # lat lon
         if isinstance(loc[0], str):
             loc = (float(loc[0]), float(loc[1]))

--- a/src/maidenhead/tests/conftest.py
+++ b/src/maidenhead/tests/conftest.py
@@ -5,6 +5,7 @@ mcmurdo = (-77.8419, 166.6863)
 washington_monument = (38.8895, -77.0353)
 giza_pyramid = (29.9792, 31.1342)
 rounding_issue = (37.1, -80.1)
+positiveonly = (37.1, 279.9)
 
 
 class Loc:
@@ -15,7 +16,7 @@ class Loc:
 
 @pytest.fixture(
     params=[(mcmurdo, "RB32id27"), (washington_monument, "FM18lv53"), (giza_pyramid, "KL59nx65"),
-            (rounding_issue, "EM97wc84")]
+            (rounding_issue, "EM97wc84"), (positiveonly, "EM97wc84")]
 )
 def location(request):
     return Loc(*request.param)

--- a/src/maidenhead/tests/conftest.py
+++ b/src/maidenhead/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 mcmurdo = (-77.8419, 166.6863)
 washington_monument = (38.8895, -77.0353)
 giza_pyramid = (29.9792, 31.1342)
+rounding_issue = (37.1, -80.1)
 
 
 class Loc:
@@ -13,7 +14,8 @@ class Loc:
 
 
 @pytest.fixture(
-    params=[(mcmurdo, "RB32id27"), (washington_monument, "FM18lv53"), (giza_pyramid, "KL59nx65")]
+    params=[(mcmurdo, "RB32id27"), (washington_monument, "FM18lv53"), (giza_pyramid, "KL59nx65"),
+            (rounding_issue, "EM97wc84")]
 )
 def location(request):
     return Loc(*request.param)

--- a/src/maidenhead/tests/test_all.py
+++ b/src/maidenhead/tests/test_all.py
@@ -12,7 +12,7 @@ def test_latlon2maiden(location):
 def test_maiden2latlon(location):
     lat, lon = maidenhead.to_location(location.maiden)
     assert lat == approx(location.latlon[0], rel=0.0001)
-    assert lon == approx(location.latlon[1], rel=0.0001)
+    assert lon == approx(location.latlon[1] if location.latlon[1] <= 180 else location.latlon[1] - 360, rel=0.0001)
 
 
 @pytest.mark.parametrize("invalid", [None, 1, True, False])


### PR DESCRIPTION
Changed the approach used to convert to and from Maidenhead locator strings.
This fixes issues caused by floating point precision errors. For example, coordinates (37.1, -80.1) would previously result in an incorrect locator.
The new approach also allows conversion to and from very long (although non-standard) Maidenhead locator strings.
This fix also addresses issue [#12](https://github.com/space-physics/maidenhead/issues/12). 



