### PR TITLE
Add support for geoJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Maidenhead provides 4 levels of increasing accuracy
   2     |  Regional
   3     |  Metropolis
   4     |  City
+  5     |  Street
+  6     |  1m precision
 
 ```sh
 pip install maidenhead
@@ -81,3 +83,5 @@ The `--center` option outputs lat lon of the center of provided maidenhead grid 
 
 Open Location Codes a.k.a Plus Codes are in
 [Python code by Google](https://github.com/google/open-location-code/tree/master/python).
+
+Web convertor [Earth Point - Tools for Google Earth](https://www.earthpoint.us/Convert.aspx).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ takes Maidenhead location string and returns top-left lat, lon of Maidenhead gri
 
 The `center=True` option outputs lat lon of the center of provided maidenhead grid square, instead of the default southwest corner.
 
+
+Maidenhead locator to [geoJSON](https://geojson.org/) ([RFC 7946](https://tools.ietf.org/html/rfc7946))
+
+```python
+geo_obj = mh.to_geoJSONObject('AB01cd', center=True, nosquare=False)
+geoJSON = json.dumps(geo_obj, indent=2)
+```
+
+
 ## Command Line
 
 The command line interface takes either decimal degrees for "latitude longitude" or the Maidenhead locator string:
@@ -78,6 +87,18 @@ python -m maidenhead 65.0 -148.0
 ```
 
 The `--center` option outputs lat lon of the center of provided maidenhead grid square, instead of the default southwest corner.
+
+
+```sh
+python -m maidenhead --center --geojson EN35ld
+```
+
+> {"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {"QTHLocator_Centerpoint": "EN35ld"}, "geometry": {"type": "Point", "coordinates": [-93.04166666666667, 45.145833333333336]}}, {"type": "Feature", "properties": {"QTHLocator": "EN35ld"}, "geometry": {"type": "Polygon", "coordinates": [[[-93.08333333333333, 45.125], [-93.08333333333333, 45.166666666666664], [-93.0, 45.166666666666664], [-93.0, 45.125], [-93.08333333333333, 45.125]]]}}]}
+
+The `--center` option enables adding center point of the grid square as Point feature.
+
+The `--nosquare` option  disables  adding Polygon feature for the requested grid square
+
 
 ## Alternatives
 

--- a/src/maidenhead/__init__.py
+++ b/src/maidenhead/__init__.py
@@ -7,7 +7,7 @@ toLoc(mloc) takes any string and returns topleft [lat,lon] within mloc
 Beyond 8 characters is not defined for Maidenhead.
 """
 
-from .to_location import to_location
+from .to_location import to_location, to_location_rect, to_geoJSONObject
 from .to_maiden import to_maiden
 
 

--- a/src/maidenhead/__main__.py
+++ b/src/maidenhead/__main__.py
@@ -7,7 +7,7 @@ import maidenhead
 
 def main(
     loc: str | tuple[float, float],
-    precision: int = 3,
+    precision: int = 6,
     url: bool = False,
     center: bool = False,
 ) -> str | tuple[float, float]:
@@ -15,7 +15,7 @@ def main(
     if isinstance(loc, str):  # maidenhead
         maiden = copy(loc)
         loc = maidenhead.to_location(loc, center)
-        print(f"{loc[0]:.4f} {loc[1]:.4f}")
+        print(f"{loc[0]:.7f} {loc[1]:.7f}")
     elif len(loc) == 2:  # lat lon
         if isinstance(loc[0], str):
             loc = (float(loc[0]), float(loc[1]))

--- a/src/maidenhead/__main__.py
+++ b/src/maidenhead/__main__.py
@@ -3,6 +3,7 @@ import argparse
 from copy import copy
 
 import maidenhead
+import json
 
 
 def main(
@@ -10,12 +11,18 @@ def main(
     precision: int = 6,
     url: bool = False,
     center: bool = False,
+    geojson: bool = False,
+    nosquare: bool = False
 ) -> str | tuple[float, float]:
 
     if isinstance(loc, str):  # maidenhead
         maiden = copy(loc)
-        loc = maidenhead.to_location(loc, center)
-        print(f"{loc[0]:.7f} {loc[1]:.7f}")
+        if geojson:
+            obj = maidenhead.to_geoJSONObject(loc, center=center, square=not nosquare)
+            print(json.dumps(obj, indent=None))
+        else:
+            loc = maidenhead.to_location(loc, center)
+            print(f"{loc[0]:.7f} {loc[1]:.7f}")
     elif len(loc) == 2:  # lat lon
         if isinstance(loc[0], str):
             loc = (float(loc[0]), float(loc[1]))
@@ -39,11 +46,17 @@ p.add_argument(
 )
 p.add_argument("-p", "--precision", help="maidenhead precision", type=int, default=3)
 p.add_argument("--url", help="also output Google Maps URL", action="store_true")
+p.add_argument("--geojson", help="Output the geoJSON that describes given QTH lcoator", action="store_true")
 p.add_argument(
     "-c",
     "--center",
     help="output lat lon of the center of provided maidenhead grid square "
     "(default output: lat lon of it's south-west corner)",
+    action="store_true",
+)
+p.add_argument(
+    "--nosquare",
+    help="Do not create square feature for geoJSON",
     action="store_true",
 )
 args = p.parse_args()
@@ -53,4 +66,4 @@ if len(args.loc) == 1:
 else:
     loc = args.loc
 
-main(loc, args.precision, args.url, args.center)
+main(loc, args.precision, args.url, args.center, args.geojson, args.nosquare)

--- a/src/maidenhead/tests/conftest.py
+++ b/src/maidenhead/tests/conftest.py
@@ -5,6 +5,7 @@ mcmurdo = (-77.8419, 166.6863)
 washington_monument = (38.8895, -77.0353)
 giza_pyramid = (29.9792, 31.1342)
 rounding_issue = (37.1, -80.1)
+positiveonly = (37.1, 279.9)
 
 
 class Loc:
@@ -15,7 +16,7 @@ class Loc:
 
 @pytest.fixture(
     params=[(mcmurdo, "RB32id27"), (washington_monument, "FM18lv53"), (giza_pyramid, "KL59nx65"),
-            (rounding_issue, "EM97wc84")]
+            (rounding_issue, "EM97wc84"), (positiveonly, "EM97wc84")]
 )
 def location(request):
     return Loc(*request.param)

--- a/src/maidenhead/tests/conftest.py
+++ b/src/maidenhead/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 mcmurdo = (-77.8419, 166.6863)
 washington_monument = (38.8895, -77.0353)
 giza_pyramid = (29.9792, 31.1342)
+rounding_issue = (37.1, -80.1)
 
 
 class Loc:
@@ -13,7 +14,8 @@ class Loc:
 
 
 @pytest.fixture(
-    params=[(mcmurdo, "RB32id27"), (washington_monument, "FM18lv53"), (giza_pyramid, "KL59nx65")]
+    params=[(mcmurdo, "RB32id27"), (washington_monument, "FM18lv53"), (giza_pyramid, "KL59nx65"),
+            (rounding_issue, "EM97wc84")]
 )
 def location(request):
     return Loc(*request.param)

--- a/src/maidenhead/tests/test_all.py
+++ b/src/maidenhead/tests/test_all.py
@@ -12,7 +12,7 @@ def test_latlon2maiden(location):
 def test_maiden2latlon(location):
     lat, lon = maidenhead.to_location(location.maiden)
     assert lat == approx(location.latlon[0], rel=0.0001)
-    assert lon == approx(location.latlon[1], rel=0.0001)
+    assert lon == approx(location.latlon[1] if location.latlon[1] <= 180 else location.latlon[1] - 360, rel=0.0001)
 
 
 @pytest.mark.parametrize("invalid", [None, 1, True, False])

--- a/src/maidenhead/to_location.py
+++ b/src/maidenhead/to_location.py
@@ -2,27 +2,7 @@ from __future__ import annotations
 import functools
 
 
-def to_location(maiden: str, center: bool = False) -> tuple[float, float]:
-    """
-    convert Maidenhead grid to latitude, longitude
-
-    Parameters
-    ----------
-
-    maiden : str
-        Maidenhead grid locator
-
-    center : bool
-        If true, return the center of provided maidenhead grid square, instead of default south-west corner
-        Default value = False needed to maidenhead full backward compatibility of this module.
-
-    Returns
-    -------
-
-    latLon : tuple of float
-        Geographic latitude, longitude
-    """
-
+def to_location_rect(maiden: str) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
     maiden = maiden.strip().upper()
     N = len(maiden)
     if N < 2 or N % 2:
@@ -46,10 +26,91 @@ def to_location(maiden: str, center: bool = False) -> tuple[float, float]:
     lat_nom, lat_den = convert(maiden[1::2])
     lon_nom, lon_den = convert(maiden[::2])
 
-    center_offset_lat = 5 if center else 0
-    center_offset_lon = 10 if center else 0
+    center_offset_lat = 5
+    center_offset_lon = 10
 
-    lat = (10 * (lat_nom - 9 * lat_den) + center_offset_lat) / lat_den
-    lon = (20 * (lon_nom - 9 * lon_den) + center_offset_lon) / lon_den
+    lat_1 = (10 * (lat_nom - 9 * lat_den)) / lat_den
+    lon_1 = (20 * (lon_nom - 9 * lon_den)) / lon_den
+    lat_c = (10 * (lat_nom - 9 * lat_den) + center_offset_lat) / lat_den
+    lon_c = (20 * (lon_nom - 9 * lon_den) + center_offset_lon) / lon_den
+    lat_2 = (10 * (lat_nom - 9 * lat_den) + 2*center_offset_lat) / lat_den
+    lon_2 = (20 * (lon_nom - 9 * lon_den) + 2*center_offset_lon) / lon_den
+    return ((lat_1, lon_1), (lat_2, lon_2), (lat_c, lon_c))
 
-    return (lat, lon)
+
+def to_location(maiden: str, center: bool = False) -> tuple[float, float]:
+    """
+    convert Maidenhead grid to latitude, longitude
+
+    Parameters
+    ----------
+
+    maiden : str
+        Maidenhead grid locator
+
+    center : bool
+        If true, return the center of provided maidenhead grid square, instead of default south-west corner
+        Default value = False needed to maidenhead full backward compatibility of this module.
+
+    Returns
+    -------
+
+    latLon : tuple of float
+        Geographic latitude, longitude
+    """
+    bottomleft_point, (_, _), center_point = to_location_rect(maiden)
+
+    return center_point if center else bottomleft_point
+
+
+def to_geoJSONObject(maiden: str, center: bool = True, square: bool = True) -> dict:
+    """
+    convert Maidenhead grid to geoJSON object as dictionary, ready to be serialized into JSON string
+
+    Parameters
+    ----------
+
+    maiden : str
+        Maidenhead grid locator
+
+    center : bool
+        If true, add Point feature for the center of provided maidenhead grid square
+
+    square : bool
+        If true, add Polygon feature for the rectangle of provided maidenhead grid square
+
+    Returns
+    -------
+
+    geo : geoJSON dict object. use json module to serialize it to string
+    """
+    loc1, loc2, locc = to_location_rect(maiden)
+    center_point = {
+        "type": "Feature",
+        "properties": {"QTHLocator_Centerpoint": maiden},
+        "geometry": {
+            "type": "Point",
+            "coordinates": [locc[1], locc[0]]
+        }
+    }
+
+    rect = {
+        "type": "Feature",
+        "properties": {"QTHLocator": maiden},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[(loc1[1], loc1[0]), (loc1[1], loc2[0]), (loc2[1], loc2[0]), (loc2[1], loc1[0]), (loc1[1], loc1[0])]]
+        }
+    }
+
+    features: list = []
+    geo = {
+        "type": "FeatureCollection",
+        "features": features
+    }
+    if center:
+        features.append(center_point)
+    if square:
+        features.append(rect)
+    # geo["features"] = features
+    return geo

--- a/src/maidenhead/to_location.py
+++ b/src/maidenhead/to_location.py
@@ -99,7 +99,7 @@ def to_geoJSONObject(maiden: str, center: bool = True, square: bool = True) -> d
         "properties": {"QTHLocator": maiden},
         "geometry": {
             "type": "Polygon",
-            "coordinates": [[(loc1[1], loc1[0]), (loc1[1], loc2[0]), (loc2[1], loc2[0]), (loc2[1], loc1[0]), (loc1[1], loc1[0])]]
+            "coordinates": [[(loc1[1], loc1[0]), (loc2[1], loc1[0]), (loc2[1], loc2[0]), (loc1[1], loc2[0]), (loc1[1], loc1[0])]]
         }
     }
 


### PR DESCRIPTION
Support conversion of Maidenhead locator to [geoJSON](https://geojson.org/) ([RFC 7946](https://tools.ietf.org/html/rfc7946))

Visualizaton can be checked at [geojson.io](https://geojson.io)

The feature  depends on pull request https://github.com/space-physics/maidenhead/pull/13